### PR TITLE
Fix GitHub Login Token

### DIFF
--- a/src/login/providers/mod.rs
+++ b/src/login/providers/mod.rs
@@ -126,7 +126,7 @@ impl Provider {
     pub async fn get_user_info(&self, scheme: Scheme, host: String, token: String) -> Result<ThirdPartyUserInfo, OauthError> {
         let user_info: OauthUserInfo = match self {
             #[cfg(feature = "github-login")]
-            Self::Github(oauth) => github::user_info(oauth, host).await?.into(),
+            Self::Github(oauth) => github::user_info(oauth, token).await?.into(),
             #[cfg(feature = "gitlab-login")]
             Self::Gitlab(oauth) => gitlab::user_info(scheme, oauth, host, token).await?.into(),
             #[cfg(feature = "google-login")]


### PR DESCRIPTION
The `host` variable was passed instead of the `token` variable when calling `get_user_info`.